### PR TITLE
skip unittest main handling so it doesn't also read from argv

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,4 +24,10 @@ if __name__ == '__main__':
 
         TestHello.MSG = a.msg
 
-    unittest.main()
+    # workaround
+
+    # from: https://stackoverflow.com/a/20266206
+
+    runner = unittest.TextTestRunner()
+    itersuite = unittest.TestLoader().loadTestsFromTestCase(TestHello)
+    runner.run(itersuite)


### PR DESCRIPTION
this is the more sensible solution. much cleaner and best if your workflow doesn't require passing args to `unittest` really